### PR TITLE
production.rbの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  # config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
# What
production.rbで以下のコードをコメントアウトした
config.assets.js_compressor = :uglifier

# Why
Capistranoのデプロイの際、Uglifier::Error: Unexpected character '`'というエラーが出てしまい、調べたところこのコードをコメントアウトすればよいと書かれていたため