### PR TITLE
production.rbの修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
# What
production.rb中、「config.assets.compile = false」を「config.assets.compile = true」に変更した

# Why
自動デプロイ後、レイアウトが崩れてしまったため、アセットファイルのコンパイルを行えるように記述を変更した。