### PR TITLE
画像アップロード先をAWS-S3に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 public/uploads/*
 public/images/*
 .DS_Store
+
+config/secrets.yml

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'font-awesome-rails'
 gem 'devise'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'fog-aws'
 
 group :production do
   gem 'unicorn', '5.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     erb2haml (0.1.5)
       html2haml
     erubis (2.7.0)
+    excon (0.64.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
@@ -93,8 +94,25 @@ GEM
     faker (1.9.3)
       i18n (>= 0.7)
     ffi (1.10.0)
+    fog-aws (3.5.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.0.4)
@@ -113,6 +131,7 @@ GEM
       ruby_parser (~> 3.5)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    ipaddress (0.8.3)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -277,6 +296,7 @@ DEPENDENCIES
   erb2haml
   factory_bot_rails
   faker
+  fog-aws
   font-awesome-rails
   haml-rails
   jbuilder (~> 2.5)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -6,7 +6,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   process resize_to_fit: [200, 200]
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
+  storage :fog
   # storage :fog
 
   # Override the directory where uploaded files will be stored.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,6 +1,13 @@
 # config valid for current version and patch releases of Capistrano
 lock "~> 3.11.0"
 
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  AWS_ACCESS_KEY_ID: ENV["AWS_ACCESS_KEY_ID"],
+  AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"]
+}
+
 set :application, "chat-space"
 set :repo_url, "git@github.com:kurogoro/chat-space.git"
 
@@ -16,11 +23,25 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+set :linked_files, %w{ config/secrets.yml }
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do
     invoke 'unicorn:restart'
   end
+
+  desc 'upload secrets.yml'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/secrets.yml', "#{shared_path}/config/secrets.yml")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
 end
 
 # Default branch is :master

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+    region: 'ap-northeast-1'
+  }
+
+  config.fog_directory  = 'kurogoro-bucket'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/kurogoro-bucket'
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,8 @@
 
 development:
   secret_key_base: be64cd3da3726e102eaafd0f904ed1708b93100cd1dd8289e9c971158466db58d214f3e5f7de606cd557d753034f96d933a628394814bee0ad3247981939c3f6
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
 
 test:
   secret_key_base: e33038707a81d29b588ad487cafe160631f997b13aa2050f21a3184ec59af2203a9bb0eac9477cfa249584f6471701d7e90980944121c0b5da4399dfa27154f7
@@ -20,3 +22,5 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>


### PR DESCRIPTION
# What
画像アップロード先をAWS-S3に変更した

# Why
Webアプリケーションを動かしているサーバに画像を保存すると容量を圧迫していくことになるので、別の保存先を用意する必要があるから