### PR TITLE
Time_zoneを日本時間に変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Asia/Tokyo'
   end
 end


### PR DESCRIPTION
# What
config/application.rbにconfig.time_zone = 'Asia/Tokyo'の記述を追加しアプリ内のtime_zoneを日本時間に変更した

# Why
Chat_spaceの投稿日時を日本時間に変更するため